### PR TITLE
Take default version according to a releases

### DIFF
--- a/Tasks/OrchestratorV2/helpers/releasehelper.ts
+++ b/Tasks/OrchestratorV2/helpers/releasehelper.ts
@@ -278,7 +278,7 @@ export class ReleaseHelper implements IReleaseHelper {
             }
 
             // Use default latest
-            let targetVersion: BuildVersion = artifact.versions![0];
+            let targetVersion: BuildVersion = artifact.defaultVersion || artifact.versions![0];
 
             // Filter primary artifact
             if (artifact.sourceId === primaryId) {


### PR DESCRIPTION
Hello @dmitryserbin ,

first let me thank you for this awesome extension. The quality overall feels in comparison to other extensions really high. 👍 

But we have one issue. We use the extension to start a really big other release with 20+ artifacts.
The artifact filter does only apply to the primary artifact, which probably is the best compromise without making it really complicated.
Unfortunately for all other artifacts the latest version is choosen which is not the default behavior when triggerin the artifact directly.
We setup our release to use a release variable to specify the branch we want for some of the artifacts. So my first try was to set this variable via release orchestrator.
This did also not effect the outcome.

I then turned on the debug output, and saw that for every artifact there is a given default version. This version looks correct for our case.

Here is an exempt from our log:

```
release-orchestrator:ReleaseHelper:getArtifacts { sourceId: 'yyy',
   alias: 'Build',
   versions:
    [ { id: '124',
        name: '1.0',
        definitionId: '5',
        definitionName: 'abc',
        sourceBranch: 'refs/heads/main',
        sourceVersion: 'xx',
        sourceRepositoryId: 'xx',
        sourceRepositoryType: 'TfsGit' },
        ...
       ],
   defaultVersion:
    { id: '123',
      name: '1.1-rc',
      definitionId: '5',
      definitionName: 'abc',
      sourceBranch: 'refs/heads/develop',
      sourceVersion: 'xx',
      sourceRepositoryId: 'xx',
      sourceRepositoryType: 'TfsGit' },
   errorMessage: null }
```

Please verify my proposed change, i think this should fix it.