### PR TITLE
Improve force stage start mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.0.*
 
+`2022-05-26`
+
+- Improve force stage start mechanism update stage ([76](https://github.com/dmitryserbin/azdev-release-orchestrator/pull/76))
+
 `2022-04-30`
 
 - Fixed BuildTags parameter not assigned ([72](https://github.com/dmitryserbin/azdev-release-orchestrator/pull/72))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 `2022-05-26`
 
-- Improve force stage start mechanism update stage ([76](https://github.com/dmitryserbin/azdev-release-orchestrator/pull/76))
+- Improve force stage start mechanism ([76](https://github.com/dmitryserbin/azdev-release-orchestrator/pull/76))
 
 `2022-04-30`
 
-- Fixed BuildTags parameter not assigned ([72](https://github.com/dmitryserbin/azdev-release-orchestrator/pull/72))
+- Fixed `buildTags` parameter not assigned ([72](https://github.com/dmitryserbin/azdev-release-orchestrator/pull/72))
 
 `2022-03-02`
 

--- a/Tasks/OrchestratorV3/common/apiclient.ts
+++ b/Tasks/OrchestratorV3/common/apiclient.ts
@@ -32,6 +32,12 @@ export class ApiClient implements IApiClient {
 
         const response: IRestResponse<any> = await this.vsoClient.restClient.get(url);
 
+        if (response.statusCode) {
+
+            debug(`Response status code <${response.statusCode}> received`);
+
+        }
+
         return response.result;
 
     }
@@ -54,11 +60,20 @@ export class ApiClient implements IApiClient {
 
         const response: IRestResponse<any> = await this.vsoClient.restClient.create(url, body, requestOptions);
 
+        if (response.statusCode) {
+
+            debug(`Response status code <${response.statusCode}> received`);
+
+        }
+
         return response.result;
 
     }
 
-    public async patch<T>(path: string, apiVersion?: string, body?: any): Promise<T> {
+    // Ability to return raw response
+    // As updateStage method requires
+    // StatusCode for success validation
+    public async patch<T>(path: string, apiVersion?: string, body?: any, raw?: boolean): Promise<T | IRestResponse<T>> {
 
         const debug = this.debugLogger.extend(this.patch.name);
 
@@ -76,7 +91,21 @@ export class ApiClient implements IApiClient {
 
         const response: IRestResponse<any> = await this.vsoClient.restClient.update(url, body, requestOptions);
 
-        return response.result;
+        if (response.statusCode) {
+
+            debug(`Response status code <${response.statusCode}> received`);
+
+        }
+
+        if (raw) {
+
+            return response;
+
+        } else {
+
+            return response.result;
+
+        }
 
     }
 
@@ -97,6 +126,12 @@ export class ApiClient implements IApiClient {
         }
 
         const response: IRestResponse<any> = await this.vsoClient.restClient.replace(url, body, requestOptions);
+
+        if (response.statusCode) {
+
+            debug(`Response status code <${response.statusCode}> received`);
+
+        }
 
         return response.result;
 
@@ -119,6 +154,12 @@ export class ApiClient implements IApiClient {
         }
 
         const response: IRestResponse<any> = await this.vsoClient.restClient.del(url, requestOptions);
+
+        if (response.statusCode) {
+
+            debug(`Response status code <${response.statusCode}> received`);
+
+        }
 
         return response.result;
 

--- a/Tasks/OrchestratorV3/common/iapiclient.ts
+++ b/Tasks/OrchestratorV3/common/iapiclient.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { IRestResponse } from "typed-rest-client";
+
 export interface IApiClient {
 
     get<T>(path: string): Promise<T>;
     post<T>(path: string, apiVersion?: string, body?: any): Promise<T>;
-    patch<T>(path: string, apiVersion?: string, body?: any): Promise<T>;
+    patch<T>(path: string, apiVersion?: string, body?: any, raw?: boolean): Promise<T | IRestResponse<T>>;
     put<T>(path: string, apiVersion?: string, body?: any): Promise<T>;
     delete<T>(path: string, apiVersion?: string): Promise<T>;
 

--- a/Tasks/OrchestratorV3/extensions/buildapiretry/buildapiretry.ts
+++ b/Tasks/OrchestratorV3/extensions/buildapiretry/buildapiretry.ts
@@ -9,13 +9,11 @@ import { IRestResponse } from "typed-rest-client";
 export class BuildApiRetry implements IBuildApiRetry {
 
     private buildApi: IBuildApi;
-
     private apiClient: IApiClient;
 
     constructor(buildApi: IBuildApi, apiClient: IApiClient) {
 
         this.buildApi = buildApi;
-
         this.apiClient = apiClient;
 
     }
@@ -131,9 +129,8 @@ export class BuildApiRetry implements IBuildApiRetry {
 
     }
 
-    // BuildApi uses old API version which does not
-    // Include forceRetryAllJobs in body. Therefore
-    // Using our own API client to make updateStage call
+    // BuildApi uses old API version which does not support forceRetryAllJobs parameter
+    // Therefore using our own implementation to make updateStage REST call
     @Retryable()
     public async updateStage(updateParameters: UpdateStageParameters, buildId: number, stageRefName: string, project?: string): Promise<void> {
 

--- a/Tasks/OrchestratorV3/extensions/buildapiretry/buildapiretry.ts
+++ b/Tasks/OrchestratorV3/extensions/buildapiretry/buildapiretry.ts
@@ -4,6 +4,7 @@ import { Build, BuildReason, BuildStatus, BuildResult, QueryDeletedOption, Build
 import { IBuildApiRetry } from "./ibuildapiretry";
 import { Retryable } from "../../common/retry";
 import { IApiClient } from "../../common/iapiclient";
+import { IRestResponse } from "typed-rest-client";
 
 export class BuildApiRetry implements IBuildApiRetry {
 
@@ -138,11 +139,11 @@ export class BuildApiRetry implements IBuildApiRetry {
 
         const run: unknown = await this.apiClient.patch(`${project}/_apis/build/builds/${buildId}/stages/${stageRefName}`, `7.1-preview.1`, updateParameters, true);
 
-        const responseCode: number | undefined = (run as any).statusCode;
+        const responseCode: number | undefined = (run as IRestResponse<number>).statusCode;
 
         const validResponseCodes: number[] = [ 200, 204 ];
 
-        if (!responseCode || validResponseCodes.includes(responseCode)) {
+        if (!responseCode || !validResponseCodes.includes(responseCode)) {
 
             throw new Error(`Unable to update <${stageRefName}> stage status`);
 

--- a/Tasks/OrchestratorV3/factories/apifactory/apifactory.ts
+++ b/Tasks/OrchestratorV3/factories/apifactory/apifactory.ts
@@ -67,7 +67,8 @@ export class ApiFactory implements IApiFactory {
         debug(`Initializing Azure DevOps Build API`);
 
         const buildApi: BuildApi = await this.webApi.getBuildApi();
-        const buildApiRetry: IBuildApiRetry = new BuildApiRetry(buildApi);
+        const apiClient: IApiClient = await this.createApiClient();
+        const buildApiRetry: IBuildApiRetry = new BuildApiRetry(buildApi, apiClient);
 
         return buildApiRetry;
 

--- a/Tasks/OrchestratorV3/helpers/stageselector/stageselector.ts
+++ b/Tasks/OrchestratorV3/helpers/stageselector/stageselector.ts
@@ -136,13 +136,13 @@ export class StageSelector implements IStageSelector {
 
             if (attempt > maxAttempts) {
 
-                throw new Error(`Unable to start <${stage.name}> (${TimelineRecordState[stage.state]}) stage progress (${attempt} sttempts)`);
+                throw new Error(`Unable to start <${stage.name}> (${TimelineRecordState[stage.state]}) stage progress (${attempt} attempts)`);
 
             }
 
             attempt++;
 
-            debug(`Validating <${stage.name}> (${stage.id}) stage start (sttempt ${attempt})`);
+            debug(`Validating <${stage.name}> (${stage.id}) stage start (attempt ${attempt})`);
 
             if (attempt == 1) {
 


### PR DESCRIPTION
BuildApi uses old API version which does not include `forceRetryAllJobs` in body. Therefore using our own API client to make updateStage using `7.1-preview` API version.

- See API version [7.1-preview](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/stages/update?view=azure-devops-rest-7.1#request-body ) VS [6.1-preview](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/stages/update?view=azure-devops-rest-6.0#stageupdatetype)
- See BuildAPI [updateStage method](https://github.com/microsoft/azure-devops-node-api/blob/184d710867475085d715951c93331c75be11f0a1/api/BuildApi.ts#L3775)

Example of issue: `release-orchestrator:Retry:retryable Executing <updateStage> with <10> retries`