### PR TITLE
Bugfix for build creation without default parameter value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,6 @@
 - Add release variables support ([24](https://github.com/dmitryserbin/azdev-release-orchestrator/issues/24))
 - Make approval retries configurable ([23](https://github.com/dmitryserbin/azdev-release-orchestrator/issues/23))
 
----
-
 ## 1.2.*
 
 `2020-08-10`
@@ -125,8 +123,6 @@
 - Improve default endpoint support
 - Increase retry & timeout
 
----
-
 ## 1.1.*
 
 `2019-03-11`
@@ -158,8 +154,6 @@
 - Major code refactor and minor bugfixes
 - Addressed intermittent ECONNRESET issue
 - Added unit and integration tests
-
----
 
 ## 1.0.*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update tasks to use Node 20.1 ([110](https://github.com/dmitryserbin/azdev-release-orchestrator/pull/110))
 - Update dependencies ([110](https://github.com/dmitryserbin/azdev-release-orchestrator/pull/110))
+- Bugfix creating a build without default parameter value ([113](https://github.com/dmitryserbin/azdev-release-orchestrator/pull/113))
 
 ## 3.1.*
 
@@ -141,7 +142,7 @@
 `2019-02-18`
 
 - Improve ignoreFailure logic
-- Minor improvements & bug fixes
+- Minor improvements & bugfixes
 
 `2019-02-15`
 
@@ -154,7 +155,7 @@
 `2019-01-24`
 
 - Added latest release strategy ([#1](https://github.com/dmitryserbin/azdev-release-orchestrator/issues/1))
-- Major code refactor and minor bug fixes
+- Major code refactor and minor bugfixes
 - Addressed intermittent ECONNRESET issue
 - Added unit and integration tests
 

--- a/tasks/OrchestratorV3/helpers/buildselector/buildselector.ts
+++ b/tasks/OrchestratorV3/helpers/buildselector/buildselector.ts
@@ -49,7 +49,7 @@ export class BuildSelector implements IBuildSelector {
 		}
 
 		if (parameters && Object.keys(parameters).length) {
-			const definitionParameters: string[] = await this.getParameters(definition, resourcesFilter.repositories.self)
+			const definitionParameters: string[] = await this.getParameters(definition, resourcesFilter.repositories.self, parameters)
 
 			await this.confirmParameters(definition, definitionParameters, parameters)
 
@@ -244,14 +244,16 @@ export class BuildSelector implements IBuildSelector {
 		return stagesToSkip
 	}
 
-	private async getParameters(definition: BuildDefinition, repository?: IRepositoryFilter): Promise<string[]> {
+	private async getParameters(definition: BuildDefinition, repository?: IRepositoryFilter, buildParameters?: IBuildParameters): Promise<string[]> {
 		const debug = this.debugLogger.extend(this.getParameters.name)
 
-		const result: any = await this.buildWebApi.getRunParameters(definition, repository)
+		const result: any = await this.buildWebApi.getRunParameters(definition, repository, buildParameters)
 
 		const templateParameters: unknown[] = result.templateParameters
 
 		if (!Array.isArray(templateParameters) || !templateParameters.length) {
+			debug(result)
+
 			throw new Error(`Unable to detect <${definition.name}> (${definition.id}) definition template parameters`)
 		}
 


### PR DESCRIPTION
A bug was fixed that prevented the creation of a build when no default parameter value was provided. The changes include updates to the parameter handling in the build selector logic.